### PR TITLE
Describe

### DIFF
--- a/couchdb-cluster-admin/add_replica_node.py
+++ b/couchdb-cluster-admin/add_replica_node.py
@@ -1,14 +1,14 @@
 import sys
 
 from utils import (
-    do_couch_request,
-    get_arg_parser,
-    node_details_from_args,
-    check_connection,
-    is_node_in_cluster,
-    confirm,
     add_node_to_cluster,
-    do_node_local_request
+    check_connection,
+    confirm,
+    do_node_local_request,
+    get_arg_parser,
+    get_db_list,
+    is_node_in_cluster,
+    node_details_from_args,
 )
 
 
@@ -71,8 +71,7 @@ if __name__ == '__main__':
         print(line)
         sys.exit(1)
 
-    dbs = do_couch_request(node_details, '_all_dbs')
-    for db_name in dbs:
+    for db_name in get_db_list(node_details, skip_private=False):
         if db_name.startswith('_'):
             # TODO: remove this once there's a workaround for https://github.com/apache/couchdb/issues/858
             print('Skipping {}'.format(db_name))

--- a/couchdb-cluster-admin/copy_db_to_new_cluster.py
+++ b/couchdb-cluster-admin/copy_db_to_new_cluster.py
@@ -5,11 +5,11 @@ import sys
 from requests.exceptions import HTTPError
 
 from utils import (
-    do_couch_request,
     check_connection,
     confirm,
     do_node_local_request,
-    NodeDetails
+    get_db_list,
+    NodeDetails,
 )
 
 
@@ -89,7 +89,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     if args.database == 'ALL':
-        dbs = do_couch_request(from_details, '_all_dbs')
+        dbs = get_db_list(from_details, skip_private=False)
     else:
         dbs = [args.database]
     print(dbs)

--- a/couchdb-cluster-admin/describe.py
+++ b/couchdb-cluster-admin/describe.py
@@ -9,11 +9,6 @@ from utils import (
 )
 
 
-def strip_couchdb(node):
-    if node.startswith('couchdb@'):
-        return node[len('couchdb@'):]
-
-
 if __name__ == '__main__':
     parser = get_arg_parser(u'Describe a couchdb cluster')
     args = parser.parse_args()
@@ -28,18 +23,6 @@ if __name__ == '__main__':
     last_header = None
     for db_name in get_db_list(node_details):
         allocation = get_shard_allocation(node_details, db_name)
-        if not allocation.validate_allocation():
-            print db_name
-            print u"In this allocation by_node and by_range are inconsistent:", repr(allocation)
-        else:
-            this_header = sorted(allocation.by_range)
-            if this_header != last_header:
-                print '\t',
-                for shard in this_header:
-                    print u'{}\t'.format(shard),
-                last_header = this_header
-                print
-            print '{}\t'.format(db_name),
-            for shard, nodes in sorted(allocation.by_range.items()):
-                print u'{}\t'.format(u','.join(map(strip_couchdb, nodes))),
-            print
+        this_header = sorted(allocation.by_range)
+        print indent(allocation.get_printable(include_shard_names=(last_header != this_header)))
+        last_header = this_header

--- a/couchdb-cluster-admin/describe.py
+++ b/couchdb-cluster-admin/describe.py
@@ -1,0 +1,25 @@
+from utils import (
+    check_connection,
+    get_arg_parser,
+    get_db_list,
+    get_membership,
+    get_shard_allocation,
+    indent,
+    node_details_from_args,
+)
+
+
+if __name__ == '__main__':
+    parser = get_arg_parser('Describe a couchdb cluster')
+    args = parser.parse_args()
+
+    node_details = node_details_from_args(args)
+    check_connection(node_details)
+
+    print 'Membership'
+    print indent(get_membership(node_details).get_printable())
+
+    print 'Shards'
+    for db_name in get_db_list(node_details):
+        print indent(db_name)
+        print indent(repr(get_shard_allocation(node_details, db_name)), n=2)

--- a/couchdb-cluster-admin/doc_models.py
+++ b/couchdb-cluster-admin/doc_models.py
@@ -31,3 +31,13 @@ class ShardAllocationDoc(JsonObject):
     @property
     def usable_shard_suffix(self):
         return ''.join(map(chr, self.shard_suffix))
+
+    def validate_allocation(self):
+        pairs_from_by_node = {(node, shard)
+                              for node, shards in self.by_node.items()
+                              for shard in shards}
+        pairs_from_by_range = {(node, shard)
+                               for shard, nodes in self.by_range.items()
+                               for node in nodes}
+
+        return pairs_from_by_node == pairs_from_by_range

--- a/couchdb-cluster-admin/doc_models.py
+++ b/couchdb-cluster-admin/doc_models.py
@@ -1,0 +1,33 @@
+from jsonobject import JsonObject, ListProperty, DictProperty, StringProperty
+
+
+class MembershipDoc(JsonObject):
+    _allow_dynamic_properties = False
+
+    cluster_nodes = ListProperty(unicode, required=True)
+    all_nodes = ListProperty(unicode, required=True)
+
+    def get_printable(self):
+        return (
+            u"cluster_nodes:\t{all_nodes}\n"
+            u"all_nodes:\t{cluster_nodes}"
+        ).format(
+            cluster_nodes=u'\t'.join(self.cluster_nodes),
+            all_nodes=u'\t'.join(self.all_nodes),
+        )
+
+
+class ShardAllocationDoc(JsonObject):
+    _allow_dynamic_properties = False
+
+    _id = StringProperty()
+    _rev = StringProperty()
+
+    by_node = DictProperty(ListProperty(unicode), required=True)
+    changelog = ListProperty(ListProperty(unicode), required=True)
+    shard_suffix = ListProperty(int, required=True)
+    by_range = DictProperty(ListProperty(unicode), required=True)
+
+    @property
+    def usable_shard_suffix(self):
+        return ''.join(map(chr, self.shard_suffix))

--- a/couchdb-cluster-admin/doc_models.py
+++ b/couchdb-cluster-admin/doc_models.py
@@ -8,12 +8,13 @@ class MembershipDoc(JsonObject):
     all_nodes = ListProperty(unicode, required=True)
 
     def get_printable(self):
+        from utils import strip_couchdb
         return (
             u"cluster_nodes:\t{all_nodes}\n"
             u"all_nodes:\t{cluster_nodes}"
         ).format(
-            cluster_nodes=u'\t'.join(self.cluster_nodes),
-            all_nodes=u'\t'.join(self.all_nodes),
+            cluster_nodes=u'\t'.join(map(strip_couchdb, self.cluster_nodes)),
+            all_nodes=u'\t'.join(map(strip_couchdb, self.all_nodes)),
         )
 
 

--- a/couchdb-cluster-admin/remove_node.py
+++ b/couchdb-cluster-admin/remove_node.py
@@ -82,6 +82,6 @@ if __name__ == '__main__':
     if remove_from_cluster:
         if confirm("Remove node {} completely from cluster?".format(node_to_remove)):
             _remove_node(node_details, node_to_remove)
-            print('Cluster membership:\n{}'.format(get_membership(node_details)))
+            print('Cluster membership:\n{}'.format(get_membership(node_details).get_printable()))
     else:
         print("Node could not be removed from cluster as it may still have shards")

--- a/couchdb-cluster-admin/remove_node.py
+++ b/couchdb-cluster-admin/remove_node.py
@@ -1,15 +1,16 @@
 import sys
 
 from utils import (
-    do_couch_request,
-    get_arg_parser,
-    node_details_from_args,
     check_connection,
-    is_node_in_cluster,
     confirm,
-    remove_node_from_cluster,
     do_node_local_request,
-    get_membership)
+    get_arg_parser,
+    get_db_list,
+    get_membership,
+    is_node_in_cluster,
+    node_details_from_args,
+    remove_node_from_cluster,
+)
 
 
 def _remove_shards_from_node(node_details, db_name, node_to_remove):
@@ -69,9 +70,8 @@ if __name__ == '__main__':
         print('Node already removed from cluster')
         sys.exit(0)
 
-    dbs = do_couch_request(node_details, '_all_dbs')
     remove_from_cluster = True
-    for db_name in dbs:
+    for db_name in get_db_list(node_details, skip_private=False):
         if db_name.startswith('_'):
             # TODO: remove this once there's a workaround for https://github.com/apache/couchdb/issues/858
             print("Skipping db {}".format(db_name))

--- a/couchdb-cluster-admin/utils.py
+++ b/couchdb-cluster-admin/utils.py
@@ -50,7 +50,7 @@ def get_arg_parser(command_description):
 
 
 def node_details_from_args(args):
-    password = getpass.getpass('Password for "{}@{}"'.format(args.username, args.control_node_ip))
+    password = getpass.getpass('Password for "{}@{}":'.format(args.username, args.control_node_ip))
     return NodeDetails(
         args.control_node_ip, args.control_node_port, args.control_node_local_port,
         args.username, password

--- a/couchdb-cluster-admin/utils.py
+++ b/couchdb-cluster-admin/utils.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 import requests
 import time
 
-from doc_models import MembershipDoc
+from doc_models import MembershipDoc, ShardAllocationDoc
 
 NodeDetails = namedtuple('NodeDetails', 'ip port node_local_port username password')
 
@@ -47,7 +47,7 @@ def get_membership(node_details):
 
 
 def get_shard_allocation(node_details, db_name):
-    return do_node_local_request(node_details, '_dbs/{}'.format(db_name))
+    return ShardAllocationDoc.wrap(do_node_local_request(node_details, '_dbs/{}'.format(db_name)))
 
 
 def confirm(msg):

--- a/couchdb-cluster-admin/utils.py
+++ b/couchdb-cluster-admin/utils.py
@@ -108,3 +108,8 @@ def is_node_in_cluster(node_details, node_to_check):
 def indent(text, n=1):
     padding = n * u'\t'
     return u''.join(padding + line for line in text.splitlines(True))
+
+
+def strip_couchdb(node):
+    if node.startswith('couchdb@'):
+        return node[len('couchdb@'):]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.18.4
+jsonobject==0.7.1


### PR DESCRIPTION
Put this together to display basic information about nodes and shards a cluster.

Currently looks something like this. (IPs and stuff changed to made-up ones.)
```
(couchdb-cluster-admin)francine:couchdb-cluster-admin droberts$ python couchdb-cluster-admin/describe.py --control-node-ip 10.1.1.2 --control-node-port 15984 --control-node-local-port 15986 --username admin
Password for "admin@10.1.1.2":
Membership
	cluster_nodes:	10.1.1.1	10.1.1.2	10.1.1.3	10.1.1.4
	all_nodes:	10.1.1.1	10.1.1.2	10.1.1.3	10.1.1.4
Shards
		00000000-1fffffff	20000000-3fffffff	40000000-5fffffff	60000000-7fffffff	80000000-9fffffff	a0000000-bfffffff	c0000000-dfffffff	e0000000-ffffffff
	commcarehq	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2
	commcarehq__apps	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2
	commcarehq__auditcare	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2
	commcarehq__domains	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2
	commcarehq__fixtures	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2
	commcarehq__fluff-bihar	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2
	commcarehq__fluff-mc	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2
	commcarehq__m4change	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2
	commcarehq__meta	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2
	commcarehq__mvp-indicators	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2
	commcarehq__receiverwrapper	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2
	commcarehq__synclogs	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2
	commcarehq__users	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2	10.1.1.2
```