### PR TITLE
Improve suggest shard allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,35 @@ all shards are currently assigned only to the first node.
 
 # Help estimating shard allocation
 
-Right now this only works if you have a single large instance that you are trying to shard
-into multiple. In order for this command to work, you must have ssh access
-to the current large machine, and read access to the couch data-dir.
-
+In order to plan out a shard reallocation, you can run the following command:
 
 ```bash
-bash couchdb-cluster-admin/size-shards.sh <remote-ip> <remote-data-dir> | python couchdb-cluster-admin/suggest_shard_allocation.py <n-nodes> <n-copies>
+python couchdb-cluster-admin/suggest_shard_allocation.py --conf config/mycluster.yml --allocate couch1:1 couch2,couch3,couch4:2
 ```
+
+The values for the `--allocate` arg in the example above should be interpreted as
+"Put 1 copy on couch1, and put 2 copies spread across couch2, couch3, and couch4".
+
+The output looks like this:
+
+```
+couch1	57.57 GB
+couch2	42.15 GB
+couch3	36.5 GB
+couch4	36.5 GB
+                     00000000-1fffffff     20000000-3fffffff     40000000-5fffffff     60000000-7fffffff     80000000-9fffffff     a0000000-bfffffff     c0000000-dfffffff     e0000000-ffffffff
+mydb                couch1,couch2,couch4  couch1,couch2,couch3  couch1,couch3,couch4  couch1,couch2,couch4  couch1,couch2,couch3  couch1,couch3,couch4  couch1,couch2,couch4  couch1,couch2,couch3
+my_second_database  couch1,couch3,couch4  couch1,couch3,couch4  couch1,couch3,couch4  couch1,couch3,couch4  couch1,couch3,couch4  couch1,couch3,couch4  couch1,couch3,couch4  couch1,couch3,couch4
+```
+
+Note, the reallocation does not take into account the current location of shards,
+so it is much more useful in the situation that you're moving from a single-node cluster
+to a multi-node cluster than it is in the situation where you're adding one more node to a multi-node cluster.
+In the example above, couch1 would be the single-node cluster and couch2, couch3, and couch4
+form are the multi-node cluster–to-be. You can imagine that after implementing
+the shard allocation suggested here, we might remove all shards from couch1 and remove it from the cluster.
+
+Note also that there is no guarantee that the "same" shard of different databases will go to the same node;
+each (db, shard)-pair is treated as an independent unit when making computing an even shard allocation.
+In this example there are only a few dbs and shards; when shards * dbs is high,
+this process can be quite good at evenly balancing your data across nodes.

--- a/couchdb-cluster-admin/describe.py
+++ b/couchdb-cluster-admin/describe.py
@@ -9,6 +9,16 @@ from utils import (
 )
 
 
+def print_shard_table(shard_allocation_docs):
+    last_header = None
+    db_names = [shard_allocation_doc.db_name for shard_allocation_doc in shard_allocation_docs]
+    max_db_name_len = max(map(len, db_names))
+    for shard_allocation_doc in shard_allocation_docs:
+        this_header = sorted(shard_allocation_doc.by_range)
+        print shard_allocation_doc.get_printable(include_shard_names=(last_header != this_header), db_name_len=max_db_name_len)
+        last_header = this_header
+
+
 if __name__ == '__main__':
     parser = get_arg_parser(u'Describe a couchdb cluster')
     args = parser.parse_args()
@@ -21,11 +31,7 @@ if __name__ == '__main__':
     print indent(get_membership(config).get_printable())
 
     print u'Shards'
-    last_header = None
-    db_names = get_db_list(node_details)
-    max_db_name_len = max(map(len, db_names))
-    for db_name in get_db_list(node_details):
-        allocation = get_shard_allocation(config, db_name)
-        this_header = sorted(allocation.by_range)
-        print indent(allocation.get_printable(include_shard_names=(last_header != this_header), db_name_len=max_db_name_len))
-        last_header = this_header
+    print_shard_table([
+        get_shard_allocation(config, db_name)
+        for db_name in sorted(get_db_list(node_details))
+    ])

--- a/couchdb-cluster-admin/doc_models.py
+++ b/couchdb-cluster-admin/doc_models.py
@@ -73,7 +73,7 @@ class ShardAllocationDoc(ConfigInjectionMixin, JsonObject):
             parts.append(u"In this allocation by_node and by_range are inconsistent:", repr(self))
         else:
             first_column = u'{{: <{}}}  '.format(db_name_len)
-            other_columns = u'{: ^17s}  '
+            other_columns = u'{: ^20s}  '
             if include_shard_names:
                 parts.append(first_column.format(u''))
                 for shard in sorted(self.by_range):

--- a/couchdb-cluster-admin/size-shards.sh
+++ b/couchdb-cluster-admin/size-shards.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-# usage:
-#   bash couchdb-cluster-admin/size-shards.sh <remote-ip> <remote-data-dir>
-
-ip=$1
-data_dir=$2
-ssh ${ip} "cd ${data_dir}/shards; find . -type f | xargs ls -alS | xargs -L 1 echo | cut -d' ' -f5,9 | sed 's|\./||g'"

--- a/couchdb-cluster-admin/suggest_shard_allocation.py
+++ b/couchdb-cluster-admin/suggest_shard_allocation.py
@@ -1,5 +1,6 @@
 from collections import namedtuple, defaultdict
 import sys
+from utils import humansize
 
 _NodeAllocation = namedtuple('_NodeAllocation', 'i size shards')
 
@@ -14,19 +15,6 @@ def suggest_shard_allocation(shard_sizes, n_nodes, n_copies):
             node.shards.append(shard)
             node.size[0] += size
     return nodes
-
-
-def humansize(nbytes):
-    """
-    Copied from https://stackoverflow.com/questions/14996453/python-libraries-to-calculate-human-readable-filesize-from-bytes#14996816
-    """
-    suffixes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
-    i = 0
-    while nbytes >= 1024 and i < len(suffixes)-1:
-        nbytes /= 1024.
-        i += 1
-    f = ('%.2f' % nbytes).rstrip('0').rstrip('.')
-    return '%s %s' % (f, suffixes[i])
 
 
 def main(keep_shards_whole=True):

--- a/couchdb-cluster-admin/suggest_shard_allocation.py
+++ b/couchdb-cluster-admin/suggest_shard_allocation.py
@@ -1,5 +1,4 @@
 from collections import namedtuple, defaultdict
-import sys
 from utils import humansize, get_arg_parser, get_config_from_args, check_connection, \
     get_db_list, get_db_metadata, get_shard_allocation
 from describe import print_shard_table
@@ -17,31 +16,6 @@ def suggest_shard_allocation(shard_sizes, n_nodes, n_copies):
             node.shards.append(shard)
             node.size[0] += size
     return nodes
-
-
-def main(keep_shards_whole=True):
-    """
-    < shard-sizes.txt python couchdb-cluster-admin/suggest_shard_allocation.py 3 2
-    """
-    shards_sizes = []
-
-    if not keep_shards_whole:
-        for line in sys.stdin.readlines():
-            size, shard = line.split()
-            shards_sizes.append((int(size), shard))
-    else:
-        whole_shard_sizes = defaultdict(int)
-        for line in sys.stdin.readlines():
-            size, shard = line.split()
-            whole_shard_sizes[shard.split('/')[0]] += int(size)
-        for whole_shard, size in whole_shard_sizes.items():
-            shards_sizes.append((size, whole_shard))
-
-    for node in suggest_shard_allocation(shards_sizes, int(sys.argv[1]), int(sys.argv[2])):
-        print "Node #{}".format(node.i + 1)
-        print humansize(node.size[0])
-        for shard in node.shards:
-            print "  {}".format(shard)
 
 
 def get_db_size(node_details, db_name):

--- a/couchdb-cluster-admin/suggest_shard_allocation.py
+++ b/couchdb-cluster-admin/suggest_shard_allocation.py
@@ -7,7 +7,7 @@ _NodeAllocation = namedtuple('_NodeAllocation', 'i size shards')
 
 
 def suggest_shard_allocation(shard_sizes, n_nodes, n_copies):
-    shard_sizes = sorted(shard_sizes)
+    shard_sizes = reversed(sorted(shard_sizes))
     # size is a list here to simulate a mutable int
     nodes = [_NodeAllocation(i, [0], []) for i in range(n_nodes)]
     for size, shard in shard_sizes:

--- a/couchdb-cluster-admin/utils.py
+++ b/couchdb-cluster-admin/utils.py
@@ -164,3 +164,16 @@ def is_node_in_cluster(node_details, node_to_check):
 def indent(text, n=1):
     padding = n * u'\t'
     return u''.join(padding + line for line in text.splitlines(True))
+
+
+def humansize(nbytes):
+    """
+    Copied from https://stackoverflow.com/questions/14996453/python-libraries-to-calculate-human-readable-filesize-from-bytes#14996816
+    """
+    suffixes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
+    i = 0
+    while nbytes >= 1024 and i < len(suffixes)-1:
+        nbytes /= 1024.
+        i += 1
+    f = ('%.2f' % nbytes).rstrip('0').rstrip('.')
+    return '%s %s' % (f, suffixes[i])

--- a/couchdb-cluster-admin/utils.py
+++ b/couchdb-cluster-admin/utils.py
@@ -44,6 +44,10 @@ def get_db_list(node_details, skip_private=True):
         return db_names
 
 
+def get_db_metadata(node_details, db_name):
+    return do_couch_request(node_details, db_name)
+
+
 def get_membership(config):
     if isinstance(config, NodeDetails):
         node_details = config

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.18.4
 jsonobject==0.7.1
 PyYAML==3.12
+gevent==1.2.2


### PR DESCRIPTION
This implements @emord's suggestion to make the shard allocation script pull just whole db sizes and assume the shards are evenly split. It also integrates it more deeply with the config file, lets you specify something a little richer about what you want to do (e.g. 1 copy one machine 1, and 2 copies across machines 2, 3, and 4), and uses the actual shard allocation doc as an intermediate format, which will make persisting this suggestion to couch as a next step just a few more lines of code.

Check the README for overall feature usage/description.