### PR TITLE
Continue improving shard allocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /config/*.yml
 !/config/conf.example.yml
-
+/plans
+/data
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ docker run --name couchdb-cluster \
 
 to start a cluster with 4 nodes. The nodes' data will be persisted to `./data`.
 
+# Optional: Set password in environment
+
+If you do not wish to specify your password every time you run a command,
+you may put its value in the `COUCHDB_CLUSTER_ADMIN_PASSWORD` environment variable like so:
+
+```
+read -sp Password: PW
+```
+
+Then, for all commands below prefex the command with `COUCHDB_CLUSTER_ADMIN_PASSWORD=$PW`, e.g.
+
+```
+COUCHDB_CLUSTER_ADMIN_PASSWORD=$PW python couchdb-admin-cluster/describe.py --conf mycluster.yml
+```
+
 # Get a quick overview of your cluster
 
 Now you can run

--- a/README.md
+++ b/README.md
@@ -11,6 +11,34 @@ cp config/conf.example.yml config/mycluster.yml
 
 and then edit it with the details of your cluster.
 
+# Setting up a local cluster to test on
+
+If you have docker installed you can just run
+
+```bash
+docker build -t couchdb-cluster - < docker-couchdb-cluster/Dockerfile
+```
+
+to build the cluster image (based on klaemo/couchdb:2.0-dev) and then run
+
+```bash
+docker run --name couchdb-cluster \
+  -p 15984:15984 \
+  -p 15986:15986 \
+  -p 25984:25984 \
+  -p 25986:25986 \
+  -p 35984:35984 \
+  -p 35986:35986 \
+  -p 45984:45984 \
+  -p 45986:45986 \
+  -v $(pwd)/data:/usr/src/couchdb/dev/lib/ \
+  -t couchdb-cluster \
+  --with-admin-party-please \
+  -n 4
+```
+
+to start a cluster with 4 nodes. The nodes' data will be persisted to `./data`.
+
 # Get a quick overview of your cluster
 
 Now you can run

--- a/couchdb-cluster-admin/file_plan.py
+++ b/couchdb-cluster-admin/file_plan.py
@@ -1,0 +1,95 @@
+import argparse
+from collections import defaultdict
+import json
+from utils import get_arg_parser, get_config_from_args, get_shard_allocation, set_up_parser
+from doc_models import ShardAllocationDoc
+from describe import print_shard_table
+
+
+def read_plan_file(filename):
+    with open(filename) as f:
+        return json.load(f)
+
+
+def update_shard_allocation_docs_from_plan(shard_allocation_docs, plan):
+    shard_allocation_docs = {shard_allocation_doc.db_name: shard_allocation_doc
+                             for shard_allocation_doc in shard_allocation_docs}
+    for db_name, by_range in sorted(plan.items()):
+        shard_allocation_doc = shard_allocation_docs[db_name]
+        by_node = defaultdict(list)
+        for shard, nodes in by_range.items():
+            for node in nodes:
+                by_node[node].append(shard)
+        shard_allocation_doc.by_range = by_range
+        shard_allocation_doc.by_node = by_node
+        assert shard_allocation_doc.validate_allocation()
+    return shard_allocation_docs
+
+
+def figure_out_what_you_can_delete(plan):
+    all_files = set()
+    important_files_by_node = defaultdict(set)
+    for db_name, by_range in plan.items():
+        for shard, nodes in by_range.items():
+            for node in nodes:
+                couch_file = 'shards/{shard}/{db_name}.*.couch'.format(
+                    shard=shard, db_name=db_name)
+                view_file = '.shards/{shard}/{db_name}.*_design'.format(
+                    shard=shard, db_name=db_name)
+                important_files_by_node[node].update([couch_file, view_file])
+                all_files.update([couch_file, view_file])
+
+    deletable_files_by_node = {}
+    for node, important_files in important_files_by_node.items():
+        deletable_files_by_node[node] = all_files - important_files
+
+    return deletable_files_by_node
+
+
+def show_plan(config, plan):
+    shard_allocation_docs = [get_shard_allocation(config, db_name) for db_name in plan]
+    update_shard_allocation_docs_from_plan(shard_allocation_docs, plan)
+    print_shard_table(shard_allocation_docs)
+
+
+def run_plan_prune(plan, node):
+    deletable_files_by_node = figure_out_what_you_can_delete(plan)
+
+    for filename in sorted(deletable_files_by_node[node]):
+        print filename
+
+
+def main():
+    parser = argparse.ArgumentParser(description=u'Helper for various manual database file operations')
+    subparsers = parser.add_subparsers(dest='command')
+    subparser_list = [subparsers.add_parser(
+        'prune',
+        help=u"List files that can be safely removed. "
+             u"(May list files that do not exist on the machine.)"
+    ), subparsers.add_parser(
+        'show-plan',
+        help=u"Just print the shard allocation table"
+    )]
+    for subparser in subparser_list:
+        set_up_parser(subparser)
+        subparser.add_argument(
+            '--node', dest='node', required=True,
+            help=u'Which node to make suggestions for.')
+        subparser.add_argument(
+            '--from-plan', dest='plan_file', required=True,
+            help=u'Get target shard allocation from plan file.')
+
+    args = parser.parse_args()
+    config = get_config_from_args(args)
+    plan = read_plan_file(args.plan_file)
+
+    if args.command == 'show-plan':
+        show_plan(config, plan)
+
+    if args.command == 'prune':
+        run_plan_prune(plan, config.get_formal_node_name(args.node))
+
+
+if __name__ == '__main__':
+    from gevent import monkey; monkey.patch_all()
+    main()

--- a/couchdb-cluster-admin/suggest_shard_allocation.py
+++ b/couchdb-cluster-admin/suggest_shard_allocation.py
@@ -119,10 +119,9 @@ def main():
                              'changing the live shard allocation.')
     args = parser.parse_args()
     config = get_config_from_args(args)
-    formal_name_lookup = {nickname: formal_name
-                          for formal_name, nickname in config.aliases.items()}
+
     allocation = [
-        ([formal_name_lookup[node] for node in nodes.split(',')], int(copies))
+        ([config.get_formal_node_name[node] for node in nodes.split(',')], int(copies))
         for nodes, copies in (group.split(':') for group in args.allocation)
     ]
     node_details = config.get_control_node()

--- a/couchdb-cluster-admin/suggest_shard_allocation.py
+++ b/couchdb-cluster-admin/suggest_shard_allocation.py
@@ -1,6 +1,7 @@
 from collections import namedtuple, defaultdict
+import json
 from utils import humansize, get_arg_parser, get_config_from_args, check_connection, \
-    get_db_list, get_db_metadata, get_shard_allocation, do_couch_request
+    get_db_list, get_db_metadata, get_shard_allocation, do_couch_request, put_shard_allocation
 from describe import print_shard_table
 
 _NodeAllocation = namedtuple('_NodeAllocation', 'i size shards')
@@ -109,6 +110,13 @@ def main():
     parser.add_argument('--allocate', dest='allocation', nargs="+", required=True,
                         help='List of nodes and how many copies you want on them, '
                              'like node1,node2,node3:<ncopies> [...]')
+
+    parser.add_argument('--save-plan', dest='plan_file', required=False,
+                        help='Save this plan to a file for use later.')
+
+    parser.add_argument('--commit-to-couchdb', dest='commit', action='store_true', required=False,
+                        help='Save the suggested allocation directly to couchdb, '
+                             'changing the live shard allocation.')
     args = parser.parse_args()
     config = get_config_from_args(args)
     formal_name_lookup = {nickname: formal_name
@@ -129,12 +137,16 @@ def main():
             for shard_name, db_name in node_allocation.shards:
                 suggested_allocation_by_db[db_name].append((nodes[node_allocation.i], shard_name))
 
-    for db_name, _, _, _, shard_allocation_doc in db_info:
+    shard_allocations = [shard_allocation_doc for _, _, _, _, shard_allocation_doc in db_info]
+
+    for shard_allocation_doc in shard_allocations:
         # have both a set for set operations and a list to preserve order
         # preserving order is useful for presenting things back to the user
         # based on the order they gave them
+        db_name = shard_allocation_doc.db_name
         suggested_allocation = suggested_allocation_by_db[db_name]
         suggested_allocation_set = set(suggested_allocation_by_db[db_name])
+        assert len(suggested_allocation) == len(suggested_allocation_set)
         current_allocation_set = {(node, shard)
                                   for shard, nodes in shard_allocation_doc.by_range.items()
                                   for node in nodes}
@@ -155,7 +167,17 @@ def main():
         ])
         assert shard_allocation_doc.validate_allocation()
 
-    print_shard_table([shard_allocation_doc for _, _, _, _, shard_allocation_doc in db_info])
+    print_shard_table([shard_allocation_doc for shard_allocation_doc in shard_allocations])
+
+    if args.plan_file:
+        with open(args.plan_file, 'w') as f:
+            json.dump({shard_allocation_doc.db_name: shard_allocation_doc.by_range
+                       for shard_allocation_doc in shard_allocations}, f)
+
+    if args.commit:
+        for shard_allocation_doc in shard_allocations:
+            print put_shard_allocation(config, shard_allocation_doc)
+
 
 
 if __name__ == '__main__':

--- a/couchdb-cluster-admin/suggest_shard_allocation.py
+++ b/couchdb-cluster-admin/suggest_shard_allocation.py
@@ -121,7 +121,7 @@ def main():
     config = get_config_from_args(args)
 
     allocation = [
-        ([config.get_formal_node_name[node] for node in nodes.split(',')], int(copies))
+        ([config.get_formal_node_name(node) for node in nodes.split(',')], int(copies))
         for nodes, copies in (group.split(':') for group in args.allocation)
     ]
     node_details = config.get_control_node()

--- a/couchdb-cluster-admin/utils.py
+++ b/couchdb-cluster-admin/utils.py
@@ -70,6 +70,16 @@ def get_shard_allocation(config, db_name):
     return shard_allocation_doc
 
 
+def put_shard_allocation(config, shard_allocation_doc):
+    node_details = config.get_control_node()
+    return do_node_local_request(
+        node_details,
+        '_dbs/{}'.format(shard_allocation_doc.db_name),
+        method='PUT',
+        json=shard_allocation_doc.to_json(),
+    )
+
+
 def confirm(msg):
     return raw_input(msg + "\n(y/n)") == 'y'
 

--- a/couchdb-cluster-admin/utils.py
+++ b/couchdb-cluster-admin/utils.py
@@ -123,6 +123,14 @@ class Config(JsonObject):
         else:
             return node
 
+    def get_formal_node_name(self, node_nickname):
+        if not hasattr(self, '_formal_name_lookup'):
+            self._formal_name_lookup = {
+                nickname: formal_name
+                for formal_name, nickname in self.aliases.items()
+            }
+        return self._formal_name_lookup[node_nickname]
+
 
 def get_config_from_args(args):
     if args.conf:

--- a/couchdb-cluster-admin/utils.py
+++ b/couchdb-cluster-admin/utils.py
@@ -1,6 +1,7 @@
 import argparse
 import getpass
 from collections import namedtuple
+import os
 from jsonobject import JsonObject, StringProperty, IntegerProperty, DictProperty
 
 import requests
@@ -136,7 +137,9 @@ def get_config_from_args(args):
             aliases=None,
         )
 
-    if config.username:
+    if 'COUCHDB_CLUSTER_ADMIN_PASSWORD' in os.environ:
+        password = os.environ['COUCHDB_CLUSTER_ADMIN_PASSWORD']
+    elif config.username:
         password = getpass.getpass('Password for "{}@{}":'.format(config.username, config.control_node_ip))
     else:
         password = None

--- a/couchdb-cluster-admin/utils.py
+++ b/couchdb-cluster-admin/utils.py
@@ -24,7 +24,7 @@ def _do_request(node_details, path, port, method='get', params=None, json=None):
     response = requests.request(
         method=method,
         url="http://{}:{}/{}".format(node_details.ip, port, path),
-        auth=(node_details.username, node_details.password),
+        auth=(node_details.username, node_details.password) if node_details.username else None,
         params=params,
         json=json,
     )
@@ -136,7 +136,10 @@ def get_config_from_args(args):
             aliases=None,
         )
 
-    password = getpass.getpass('Password for "{}@{}":'.format(config.username, config.control_node_ip))
+    if config.username:
+        password = getpass.getpass('Password for "{}@{}":'.format(config.username, config.control_node_ip))
+    else:
+        password = None
     config.set_password(password)
     return config
 

--- a/couchdb-cluster-admin/utils.py
+++ b/couchdb-cluster-admin/utils.py
@@ -87,6 +87,11 @@ def confirm(msg):
 
 def get_arg_parser(command_description):
     parser = argparse.ArgumentParser(description=command_description)
+    set_up_parser(parser)
+    return parser
+
+
+def set_up_parser(parser):
     parser.add_argument('--conf', dest='conf')
     parser.add_argument('--control-node-ip', dest='control_node_ip',
                         help='IP of an existing node in the cluster')
@@ -96,7 +101,6 @@ def get_arg_parser(command_description):
                         help='Port of control node. Default: 15984')
     parser.add_argument('--control-node-local-port', dest='control_node_local_port', default=15986, type=int,
                         help='Port of control node for local operations. Default: 15986')
-    return parser
 
 
 class Config(JsonObject):

--- a/docker-couchdb-cluster/Dockerfile
+++ b/docker-couchdb-cluster/Dockerfile
@@ -1,0 +1,3 @@
+FROM klaemo/couchdb:2.0-dev
+
+RUN sed -i'' 's/bind_address = 127.0.0.1/bind_address = 0.0.0.0/' rel/overlay/etc/default.ini


### PR DESCRIPTION
Best reviewed commit by commit.

This gets us a little further in terms of doing a real shard reallocation. You can now:
- save a suggested allocation to a "plan file" with `.../suggest_shard_allocation.py ... --save-plan`
- you can actually commit a plan to couchdb (thus reallocating the shards as suggested) with `.../suggest_shard_allocation.py ... --commit-to-couchdb`
- you can print out a list of couchdb db files that you can safely delete from any given node, given a particular plan file. I used this to reclaim disk on the nodes when their disks filled. The command is
  ```bash
  python couchdb-cluster-admin/file_plan.py show-plan --conf config/mycluster.yml --from-
  plan=mycluster.plan.json --node couch2
  ```

Still need to do _after_ this PR:
- allow `suggest_shard_allocation.py` to read in a plan file and commit it to couch—otherwise there's no way of knowing in advance for sure what it's going to commit, and if you can't commit a plan file it's essentially useless
- Allow `file_plan.py` to generate an rsync command that you can run to copy everything except the excludable files. This will allow us to selectively copy over just the shards that are prescribed in the plan file. (It's going to be really long and have a bunch of `--exclude file1 --exclude file2 --exclude file3 ...`.)