### PR TITLE
Create databases in the target cluster if they don't already exists

### DIFF
--- a/couchdb-cluster-admin/doc_models.py
+++ b/couchdb-cluster-admin/doc_models.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from jsonobject import JsonObject, ListProperty, DictProperty, StringProperty
 
 
@@ -49,6 +50,36 @@ class ShardAllocationDoc(ConfigInjectionMixin, JsonObject):
     @property
     def db_name(self):
         return self._id
+
+    def to_plan_json(self):
+        return {
+            'by_range': self.by_range,
+            'shard_suffix': self.usable_shard_suffix
+        }
+
+    @classmethod
+    def from_plan_json(self, db_name, plan_json):
+        shard_suffix = [ord(c) for c in plan_json['shard_suffix']]
+        doc = ShardAllocationDoc(_id=db_name, shard_suffix=shard_suffix)
+        doc.populate_from_range(plan_json['by_range'])
+        return doc
+
+    def populate_from_range(self, by_range):
+        self.by_range = by_range
+        self.by_node = self._populate_other(by_range)
+        assert self.validate_allocation()
+
+    def populate_from_nodes(self, by_node):
+        self.by_node = by_node
+        self.by_range = self._populate_other(by_node)
+        self.validate_allocation()
+
+    def _populate_other(self, by_item):
+        by_other = defaultdict(list)
+        for key, values in by_item.items():
+            for value in values:
+                by_other[value].append(key)
+        return dict(by_other)
 
     def validate_allocation(self):
         pairs_from_by_node = {(node, shard)

--- a/couchdb-cluster-admin/doc_models.py
+++ b/couchdb-cluster-admin/doc_models.py
@@ -35,7 +35,7 @@ class ShardAllocationDoc(ConfigInjectionMixin, JsonObject):
     _allow_dynamic_properties = False
 
     _id = StringProperty()
-    _rev = StringProperty()
+    _rev = StringProperty(exclude_if_none=True)
 
     by_node = DictProperty(ListProperty(unicode), required=True)
     changelog = ListProperty(ListProperty(unicode), required=True)

--- a/couchdb-cluster-admin/doc_models.py
+++ b/couchdb-cluster-admin/doc_models.py
@@ -38,10 +38,10 @@ class ShardAllocationDoc(ConfigInjectionMixin, JsonObject):
     _id = StringProperty()
     _rev = StringProperty(exclude_if_none=True)
 
-    by_node = DictProperty(ListProperty(unicode), required=True)
-    changelog = ListProperty(ListProperty(unicode), required=True)
-    shard_suffix = ListProperty(int, required=True)
-    by_range = DictProperty(ListProperty(unicode), required=True)
+    by_node = DictProperty(ListProperty(unicode))
+    changelog = ListProperty(ListProperty(unicode))
+    shard_suffix = ListProperty(int)
+    by_range = DictProperty(ListProperty(unicode))
 
     @property
     def usable_shard_suffix(self):

--- a/couchdb-cluster-admin/file_plan.py
+++ b/couchdb-cluster-admin/file_plan.py
@@ -3,12 +3,17 @@ from collections import defaultdict
 import json
 from utils import get_config_from_args, get_shard_allocation, set_up_parser
 from describe import print_shard_table
+from doc_models import ShardAllocationDoc
 
 
 def read_plan_file(filename):
     with open(filename) as f:
-        return json.load(f)
+        plan = json.load(f)
 
+    return {
+        db_name: ShardAllocationDoc.from_plan_json(db_name, plan_json)
+        for db_name, plan_json in plan.items()
+    }
 
 def update_shard_allocation_docs_from_plan(shard_allocation_docs, plan):
     shard_allocation_docs = {shard_allocation_doc.db_name: shard_allocation_doc

--- a/couchdb-cluster-admin/file_plan.py
+++ b/couchdb-cluster-admin/file_plan.py
@@ -18,30 +18,27 @@ def read_plan_file(filename):
 def update_shard_allocation_docs_from_plan(shard_allocation_docs, plan):
     shard_allocation_docs = {shard_allocation_doc.db_name: shard_allocation_doc
                              for shard_allocation_doc in shard_allocation_docs}
-    for db_name, by_range in sorted(plan.items()):
+    for db_name, allocation_doc in sorted(plan.items()):
         shard_allocation_doc = shard_allocation_docs[db_name]
-        by_node = defaultdict(list)
-        for shard, nodes in by_range.items():
-            for node in nodes:
-                by_node[node].append(shard)
-        shard_allocation_doc.by_range = by_range
-        shard_allocation_doc.by_node = by_node
+        shard_allocation_doc.by_range = allocation_doc.by_range
+        shard_allocation_doc.by_node = allocation_doc.by_node
         assert shard_allocation_doc.validate_allocation()
     return shard_allocation_docs
 
 
-def figure_out_what_you_can_and_cannot_delete(config, plan, shard_suffix_by_db_name=None):
-    if shard_suffix_by_db_name is None:
+def figure_out_what_you_can_and_cannot_delete(plan, shard_suffix_by_db_name=None):
+    if not shard_suffix_by_db_name:
         shard_suffix_by_db_name = defaultdict(lambda: '.*')
     all_files = set()
     important_files_by_node = defaultdict(set)
-    for db_name, by_range in plan.items():
-        for shard, nodes in by_range.items():
+    for db_name, allocation_doc in plan.items():
+        shard_suffix = shard_suffix_by_db_name.get(db_name, None)
+        for shard, nodes in allocation_doc.by_range.items():
             for node in nodes:
                 couch_file = 'shards/{shard}/{db_name}{shard_suffix}.couch'.format(
-                    shard=shard, db_name=db_name, shard_suffix=shard_suffix_by_db_name[db_name])
+                    shard=shard, db_name=db_name, shard_suffix=shard_suffix)
                 view_file = '.shards/{shard}/{db_name}{shard_suffix}_design'.format(
-                    shard=shard, db_name=db_name, shard_suffix=shard_suffix_by_db_name[db_name])
+                    shard=shard, db_name=db_name, shard_suffix=shard_suffix)
 
                 important_files_by_node[node].add(couch_file)
                 all_files.add(couch_file)
@@ -63,24 +60,35 @@ def assemble_shard_allocations_from_plan(config, plan):
 
 
 def show_plan(config, plan):
-    shard_allocation_docs = assemble_shard_allocations_from_plan(config, plan)
+    shard_allocation_docs = plan.values()
+    for doc in shard_allocation_docs:
+        doc.set_config(config)
     print_shard_table(shard_allocation_docs)
+
+
+def _get_shard_suffixes(config, plan):
+    shard_suffix_by_db_name = {}
+    for db_name, planed_allocation in plan.items():
+        db_allocation = get_shard_allocation(config, db_name)
+
+        if planed_allocation.shard_suffix:
+            assert db_allocation.shard_suffix == planed_allocation.shard_suffix
+
+        shard_suffix_by_db_name[db_name] = db_allocation.usable_shard_suffix
+
+    return shard_suffix_by_db_name
 
 
 def run_plan_prune(config, plan, node):
     _, deletable_files_by_node = figure_out_what_you_can_and_cannot_delete(
-        config, plan, shard_allocation_docs)
+        plan, _get_shard_suffixes(config, plan))
     for filename in sorted(deletable_files_by_node[node]):
         print filename
 
 
 def run_important_plan(config, plan, node):
-    shard_suffix_by_db_name = {
-        db_name: get_shard_allocation(config, db_name).usable_shard_suffix
-        for db_name in plan
-    }
     important_files_by_node, _ = figure_out_what_you_can_and_cannot_delete(
-        config, plan, shard_suffix_by_db_name)
+        plan, _get_shard_suffixes(config, plan))
     for filename in sorted(important_files_by_node[node]):
         print filename
 

--- a/couchdb-cluster-admin/suggest_shard_allocation.py
+++ b/couchdb-cluster-admin/suggest_shard_allocation.py
@@ -159,7 +159,7 @@ def apply_suggested_allocation(shard_allocations, plan):
             for node, shard in current_allocation_set - suggested_allocation_set
         ])
         if shard_allocation_doc.shard_suffix:
-            assert shard_allocation_doc.shard_suffix ==  suggested_allocation.shard_suffix
+            assert shard_allocation_doc.shard_suffix == suggested_allocation.shard_suffix
         else:
             shard_allocation_doc.shard_suffix = suggested_allocation.shard_suffix
 

--- a/couchdb-cluster-admin/suggest_shard_allocation.py
+++ b/couchdb-cluster-admin/suggest_shard_allocation.py
@@ -184,6 +184,10 @@ def main():
     parser.add_argument('--commit-to-couchdb', dest='commit', action='store_true', required=False,
                         help='Save the suggested allocation directly to couchdb, '
                              'changing the live shard allocation.')
+
+    parser.add_argument('--create-missing-databases', dest='create', action='store_true', required=False,
+                        help="Create databases in the cluster if they don't exist.")
+
     args = parser.parse_args()
     config = get_config_from_args(args)
 
@@ -209,7 +213,7 @@ def main():
         )
     else:
         plan = read_plan_file(args.plan_file)
-        shard_allocations_docs = [get_shard_allocation(config, db_name) for db_name in plan]
+        shard_allocations_docs = [get_shard_allocation(config, db_name, args.create) for db_name in plan]
         shard_allocations = apply_suggested_allocation(
             shard_allocations_docs, plan
         )

--- a/couchdb-cluster-admin/suggest_shard_allocation.py
+++ b/couchdb-cluster-admin/suggest_shard_allocation.py
@@ -158,8 +158,11 @@ def apply_suggested_allocation(shard_allocations, plan):
             ["delete", shard, node]
             for node, shard in current_allocation_set - suggested_allocation_set
         ])
-        if not shard_allocation_doc.shard_suffix:
+        if shard_allocation_doc.shard_suffix:
+            assert shard_allocation_doc.shard_suffix ==  suggested_allocation.shard_suffix
+        else:
             shard_allocation_doc.shard_suffix = suggested_allocation.shard_suffix
+
         assert shard_allocation_doc.validate_allocation()
     return shard_allocations
 

--- a/couchdb-cluster-admin/utils.py
+++ b/couchdb-cluster-admin/utils.py
@@ -7,6 +7,7 @@ from jsonobject import JsonObject, StringProperty, IntegerProperty, DictProperty
 import requests
 import time
 import yaml
+from requests import HTTPError
 
 from doc_models import MembershipDoc, ShardAllocationDoc
 
@@ -73,7 +74,14 @@ def get_shard_allocation(config, db_name):
         config = None
     else:
         node_details = config.get_control_node()
-    shard_allocation_doc = ShardAllocationDoc.wrap(do_node_local_request(node_details, '_dbs/{}'.format(db_name)))
+    try:
+        shard_allocation_doc = ShardAllocationDoc.wrap(do_node_local_request(node_details, '_dbs/{}'.format(db_name)))
+    except HTTPError as e:
+        if e.response.status_code == 404:
+            shard_allocation_doc = ShardAllocationDoc(_id=db_name)
+        else:
+            raise
+
     shard_allocation_doc.set_config(config)
     return shard_allocation_doc
 

--- a/couchdb-cluster-admin/utils.py
+++ b/couchdb-cluster-admin/utils.py
@@ -68,7 +68,7 @@ def get_membership(config):
     return membership_doc
 
 
-def get_shard_allocation(config, db_name):
+def get_shard_allocation(config, db_name, create=False):
     if isinstance(config, NodeDetails):
         node_details = config
         config = None
@@ -78,7 +78,11 @@ def get_shard_allocation(config, db_name):
         shard_allocation_doc = ShardAllocationDoc.wrap(do_node_local_request(node_details, '_dbs/{}'.format(db_name)))
     except HTTPError as e:
         if e.response.status_code == 404:
-            shard_allocation_doc = ShardAllocationDoc(_id=db_name)
+            if create:
+                shard_allocation_doc = ShardAllocationDoc(_id=db_name)
+            else:
+                raise Exception('Database "{}" does not exist. Use "--create-missing-databases" flag if you want'
+                                ' to have the database created when the plan is committed.'.format(db_name))
         else:
             raise
 


### PR DESCRIPTION
Hit this when using this tool for the ICDS cluster migration. The gist here is:
* save the `shard_suffix` in the plan so that we can use it to create the new db doc later
* when loading the plan re-create the `ShardAllocationDoc`s