### PR TITLE
Include private dbs in shard migrations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python: "2.7"
 before_install:
   - git clone https://github.com/sstephenson/bats.git
   - cd bats
+  - git checkout v0.4.0
   - sudo ./install.sh /usr/local
   - cd -
 install:

--- a/couchdb_cluster_admin/add_replica_node.py
+++ b/couchdb_cluster_admin/add_replica_node.py
@@ -71,7 +71,7 @@ if __name__ == '__main__':
         print(line)
         sys.exit(1)
 
-    for db_name in get_db_list(node_details, skip_private=False):
+    for db_name in get_db_list(node_details):
         if db_name.startswith('_'):
             # TODO: remove this once there's a workaround for https://github.com/apache/couchdb/issues/858
             print('Skipping {}'.format(db_name))

--- a/couchdb_cluster_admin/copy_db_to_new_cluster.py
+++ b/couchdb_cluster_admin/copy_db_to_new_cluster.py
@@ -95,7 +95,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     if args.database == 'ALL':
-        dbs = get_db_list(from_details, skip_private=False)
+        dbs = get_db_list(from_details)
     else:
         dbs = [args.database]
     print(dbs)

--- a/couchdb_cluster_admin/file_plan.py
+++ b/couchdb_cluster_admin/file_plan.py
@@ -58,8 +58,12 @@ def figure_out_what_you_can_and_cannot_delete(plan, shard_suffix_by_db_name=None
                 all_filenames.add(couch_file_name)
 
                 view_file = Nodefile(db_name, node, shard, view_file_name)
-                important_files_by_node[node].add(view_file)
-                all_filenames.add(view_file_name)
+                # _global_changes doesn't have any views, so there's no view file
+                # The same is true of _any_ db with no views, but it's rare enough
+                # that I'm just cutting corners for simplicity
+                if db_name != '_global_changes':
+                    important_files_by_node[node].add(view_file)
+                    all_filenames.add(view_file_name)
 
     deletable_files_by_node = {}
     for node, important_files in important_files_by_node.items():

--- a/couchdb_cluster_admin/remove_node.py
+++ b/couchdb_cluster_admin/remove_node.py
@@ -71,7 +71,7 @@ if __name__ == '__main__':
         sys.exit(0)
 
     remove_from_cluster = True
-    for db_name in get_db_list(node_details, skip_private=False):
+    for db_name in get_db_list(node_details):
         if db_name.startswith('_'):
             # TODO: remove this once there's a workaround for https://github.com/apache/couchdb/issues/858
             print("Skipping db {}".format(db_name))

--- a/couchdb_cluster_admin/utils.py
+++ b/couchdb_cluster_admin/utils.py
@@ -41,16 +41,9 @@ def _do_request(node_details, path, port, method='get', params=None, json=None):
     return response.json()
 
 
-def get_db_list(node_details, skip_private=True):
-    """
-    :param skip_private: if True, exclude dbs that start with an underscore from the result
-    :return: list of dbs
-    """
+def get_db_list(node_details):
     db_names = do_couch_request(node_details, '_all_dbs')
-    if skip_private:
-        return [db_name for db_name in db_names if not db_name.startswith('_')]
-    else:
-        return db_names
+    return db_names
 
 
 def get_db_metadata(node_details, db_name):

--- a/test/test.bats
+++ b/test/test.bats
@@ -4,6 +4,11 @@ function setup {
     db_name=test$(head -n20 /dev/random | python -c 'import hashlib, sys; print hashlib.md5(sys.stdin.read()).hexdigest()')
     echo "PUT" $db_name
     curl -sX PUT http://localhost:15984/${db_name}
+    curl -sX PUT http://localhost:15984/_users/org.couchdb.user:jan \
+     -H "Accept: application/json" \
+     -H "Content-Type: application/json" \
+     -d '{"name": "jan", "password": "apple", "roles": [], "type": "user"}'
+
 }
 
 function doccount {

--- a/test/test.bats
+++ b/test/test.bats
@@ -72,6 +72,16 @@ function wait_for_couch_ping {
     python couchdb_cluster_admin/suggest_shard_allocation.py --conf=test/local.yml --from-plan=test/local.plan.json --commit-to-couchdb
 
     echo $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount)
+    sleep 5
+    echo $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount)
+    sleep 5
+    echo $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount)
+    sleep 5
+    echo $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount)
+    sleep 5
+    echo $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount)
+    sleep 5
+    echo $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount)
     [ "$(doccount)" = '10' ]
     echo $(longform_doccount) $(longform_doccount) $(longform_doccount)
     [ "$(longform_doccount)" = '10' ]

--- a/test/test.bats
+++ b/test/test.bats
@@ -4,6 +4,7 @@ function setup {
     db_name=test$(head -n20 /dev/random | python -c 'import hashlib, sys; print hashlib.md5(sys.stdin.read()).hexdigest()')
     echo "PUT" $db_name
     curl -sX PUT http://localhost:15984/${db_name}
+    curl -sX PUT http://localhost:15984/_users
     curl -sX PUT http://localhost:15984/_users/org.couchdb.user:jan \
      -H "Accept: application/json" \
      -H "Content-Type: application/json" \


### PR DESCRIPTION
I think I was misguided by initially excluding them.
_global_changes, _replicator, and _users need to have their shards migrated
like any other db

Ran into this when removing the old couch nodes on prod. It didn't cause any service interruptions or anything, but I noticed those dbs were 500ing when I shut down the old nodes. After bringing them back up and re-running with these changes, I could shut the old nodes down no problem.