### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/couchdb_cluster_admin/__init__.py
+++ b/couchdb_cluster_admin/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = "0.4.2"
+__version__ = "0.5.0"


### PR DESCRIPTION
Decided to go with a minor (rather than hotfix) version because this contains significant new functionality over the previous release (0.4.2).