### PR TITLE
Upgrade to support python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 ---
 sudo: required
 language: python
-python: "2.7"
+python: 
+  - "2.7"
+  - "3.6"
 before_install:
   - git clone https://github.com/sstephenson/bats.git
   - cd bats

--- a/couchdb_cluster_admin/add_replica_node.py
+++ b/couchdb_cluster_admin/add_replica_node.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import sys
 
-from utils import (
+from .utils import (
     add_node_to_cluster,
     check_connection,
     confirm,
@@ -16,7 +18,7 @@ def _update_db_doc_with_new_node(node_details, db_name, new_node):
     db_doc = do_node_local_request(node_details, '_dbs/{}'.format(db_name))
     by_node = db_doc['by_node']
     if new_node in by_node:
-        print('  Node "{}" already has shards for db "{}"'.format(new_node, db_name))
+        print(('  Node "{}" already has shards for db "{}"'.format(new_node, db_name)))
         return
 
     shards_for_new_node = None
@@ -26,7 +28,7 @@ def _update_db_doc_with_new_node(node_details, db_name, new_node):
             break
 
     if not shards_for_new_node:
-        print('Unable to find shards for db {}'.format(db_name))
+        print(('Unable to find shards for db {}'.format(db_name)))
         return
 
     print('  Adding shards to new node:\n')
@@ -36,12 +38,12 @@ def _update_db_doc_with_new_node(node_details, db_name, new_node):
     for shard in shards_for_new_node:
         current_nodes = db_doc['by_range'][shard]
         if new_node not in current_nodes:
-            print('    {}'.format(shard))
+            print(('    {}'.format(shard)))
             current_nodes.append(new_node)
         else:
-            print('    Node already had shard: {}'.format(shard))
+            print(('    Node already had shard: {}'.format(shard)))
 
-    print('  Updating db config for {}'.format(db_name))
+    print(('  Updating db config for {}'.format(db_name)))
     do_node_local_request(node_details, '_dbs/{}'.format(db_name), method='put', json=db_doc)
 
 
@@ -74,7 +76,7 @@ if __name__ == '__main__':
     for db_name in get_db_list(node_details):
         if db_name.startswith('_'):
             # TODO: remove this once there's a workaround for https://github.com/apache/couchdb/issues/858
-            print('Skipping {}'.format(db_name))
+            print(('Skipping {}'.format(db_name)))
             continue
         if confirm('Add shards from db "{}" to new node?'.format(db_name)):
             _update_db_doc_with_new_node(node_details, db_name, new_node)

--- a/couchdb_cluster_admin/add_replica_node.py
+++ b/couchdb_cluster_admin/add_replica_node.py
@@ -18,7 +18,7 @@ def _update_db_doc_with_new_node(node_details, db_name, new_node):
     db_doc = do_node_local_request(node_details, '_dbs/{}'.format(db_name))
     by_node = db_doc['by_node']
     if new_node in by_node:
-        print(('  Node "{}" already has shards for db "{}"'.format(new_node, db_name)))
+        print('  Node "{}" already has shards for db "{}"'.format(new_node, db_name))
         return
 
     shards_for_new_node = None
@@ -28,7 +28,7 @@ def _update_db_doc_with_new_node(node_details, db_name, new_node):
             break
 
     if not shards_for_new_node:
-        print(('Unable to find shards for db {}'.format(db_name)))
+        print('Unable to find shards for db {}'.format(db_name))
         return
 
     print('  Adding shards to new node:\n')
@@ -38,12 +38,12 @@ def _update_db_doc_with_new_node(node_details, db_name, new_node):
     for shard in shards_for_new_node:
         current_nodes = db_doc['by_range'][shard]
         if new_node not in current_nodes:
-            print(('    {}'.format(shard)))
+            print('    {}'.format(shard))
             current_nodes.append(new_node)
         else:
-            print(('    Node already had shard: {}'.format(shard)))
+            print('    Node already had shard: {}'.format(shard))
 
-    print(('  Updating db config for {}'.format(db_name)))
+    print('  Updating db config for {}'.format(db_name))
     do_node_local_request(node_details, '_dbs/{}'.format(db_name), method='put', json=db_doc)
 
 
@@ -76,7 +76,7 @@ if __name__ == '__main__':
     for db_name in get_db_list(node_details):
         if db_name.startswith('_'):
             # TODO: remove this once there's a workaround for https://github.com/apache/couchdb/issues/858
-            print(('Skipping {}'.format(db_name)))
+            print('Skipping {}'.format(db_name))
             continue
         if confirm('Add shards from db "{}" to new node?'.format(db_name)):
             _update_db_doc_with_new_node(node_details, db_name, new_node)

--- a/couchdb_cluster_admin/copy_db_to_new_cluster.py
+++ b/couchdb_cluster_admin/copy_db_to_new_cluster.py
@@ -1,10 +1,12 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import argparse
 import getpass
 import sys
 
 from requests.exceptions import HTTPError
 
-from utils import (
+from .utils import (
     check_connection,
     confirm,
     do_node_local_request,
@@ -20,7 +22,7 @@ def _copy_db_doc(from_details, to_details, db_name):
         if e.response.status_code != 404:
             raise
     else:
-        print("{} already exists in destination cluster".format(db_name))
+        print(("{} already exists in destination cluster".format(db_name)))
         return
 
     from_db_doc = do_node_local_request(from_details, '_dbs/{}'.format(db_name))
@@ -39,7 +41,7 @@ def _copy_db_doc(from_details, to_details, db_name):
             break
 
     if not db_shards:
-        print('Unable to find shards for db {}'.format(db_name))
+        print(('Unable to find shards for db {}'.format(db_name)))
         return
 
     for detail in to_details:
@@ -49,7 +51,7 @@ def _copy_db_doc(from_details, to_details, db_name):
     for shard in db_shards:
         to_db_doc['by_range'][shard] = nodes
 
-    print('  Updating db config for {}'.format(db_name))
+    print(('  Updating db config for {}'.format(db_name)))
     do_node_local_request(to_details[0], '_dbs/{}'.format(db_name), method='put', json=to_db_doc)
 
 
@@ -101,6 +103,6 @@ if __name__ == '__main__':
     print(dbs)
     for db_name in dbs:
         if db_name.startswith('_'):
-            print('Skipping {}'.format(db_name))
+            print(('Skipping {}'.format(db_name)))
             continue
         _copy_db_doc(from_details, to_details, db_name)

--- a/couchdb_cluster_admin/copy_db_to_new_cluster.py
+++ b/couchdb_cluster_admin/copy_db_to_new_cluster.py
@@ -22,7 +22,7 @@ def _copy_db_doc(from_details, to_details, db_name):
         if e.response.status_code != 404:
             raise
     else:
-        print(("{} already exists in destination cluster".format(db_name)))
+        print("{} already exists in destination cluster".format(db_name))
         return
 
     from_db_doc = do_node_local_request(from_details, '_dbs/{}'.format(db_name))
@@ -41,7 +41,7 @@ def _copy_db_doc(from_details, to_details, db_name):
             break
 
     if not db_shards:
-        print(('Unable to find shards for db {}'.format(db_name)))
+        print('Unable to find shards for db {}'.format(db_name))
         return
 
     for detail in to_details:
@@ -51,7 +51,7 @@ def _copy_db_doc(from_details, to_details, db_name):
     for shard in db_shards:
         to_db_doc['by_range'][shard] = nodes
 
-    print(('  Updating db config for {}'.format(db_name)))
+    print('  Updating db config for {}'.format(db_name))
     do_node_local_request(to_details[0], '_dbs/{}'.format(db_name), method='put', json=to_db_doc)
 
 
@@ -103,6 +103,6 @@ if __name__ == '__main__':
     print(dbs)
     for db_name in dbs:
         if db_name.startswith('_'):
-            print(('Skipping {}'.format(db_name)))
+            print('Skipping {}'.format(db_name))
             continue
         _copy_db_doc(from_details, to_details, db_name)

--- a/couchdb_cluster_admin/describe.py
+++ b/couchdb_cluster_admin/describe.py
@@ -1,4 +1,6 @@
-from utils import (
+from __future__ import absolute_import
+from __future__ import print_function
+from .utils import (
     check_connection,
     get_arg_parser,
     get_config_from_args,
@@ -7,15 +9,16 @@ from utils import (
     get_shard_allocation,
     indent,
 )
+from six.moves import map
 
 
 def print_shard_table(shard_allocation_docs):
     last_header = None
     db_names = [shard_allocation_doc.db_name for shard_allocation_doc in shard_allocation_docs]
-    max_db_name_len = max(map(len, db_names))
+    max_db_name_len = max(list(map(len, db_names)))
     for shard_allocation_doc in shard_allocation_docs:
         this_header = sorted(shard_allocation_doc.by_range)
-        print shard_allocation_doc.get_printable(include_shard_names=(last_header != this_header), db_name_len=max_db_name_len)
+        print(shard_allocation_doc.get_printable(include_shard_names=(last_header != this_header), db_name_len=max_db_name_len))
         last_header = this_header
 
 
@@ -27,10 +30,10 @@ if __name__ == '__main__':
     node_details = config.get_control_node()
     check_connection(node_details)
 
-    print u'Membership'
-    print indent(get_membership(config).get_printable())
+    print(u'Membership')
+    print(indent(get_membership(config).get_printable()))
 
-    print u'Shards'
+    print(u'Shards')
     print_shard_table([
         get_shard_allocation(config, db_name)
         for db_name in sorted(get_db_list(node_details))

--- a/couchdb_cluster_admin/doc_models.py
+++ b/couchdb_cluster_admin/doc_models.py
@@ -1,11 +1,14 @@
+from __future__ import absolute_import
 from collections import defaultdict
 from jsonobject import JsonObject, ListProperty, DictProperty, StringProperty, IntegerProperty
+from six.moves import map
+import six
 
 
 class ConfigInjectionMixin(object):
     @property
     def config(self):
-        from utils import Config
+        from .utils import Config
         try:
             return self._config
         except AttributeError:
@@ -19,8 +22,8 @@ class ConfigInjectionMixin(object):
 class MembershipDoc(ConfigInjectionMixin, JsonObject):
     _allow_dynamic_properties = False
 
-    cluster_nodes = ListProperty(unicode, required=True)
-    all_nodes = ListProperty(unicode, required=True)
+    cluster_nodes = ListProperty(six.text_type, required=True)
+    all_nodes = ListProperty(six.text_type, required=True)
 
     def get_printable(self):
         return (
@@ -38,10 +41,10 @@ class ShardAllocationDoc(ConfigInjectionMixin, JsonObject):
     _id = StringProperty()
     _rev = StringProperty(exclude_if_none=True)
 
-    by_node = DictProperty(ListProperty(unicode))
-    changelog = ListProperty(ListProperty(unicode))
+    by_node = DictProperty(ListProperty(six.text_type))
+    changelog = ListProperty(ListProperty(six.text_type))
     shard_suffix = ListProperty(int)
-    by_range = DictProperty(ListProperty(unicode))
+    by_range = DictProperty(ListProperty(six.text_type))
 
     @property
     def usable_shard_suffix(self):
@@ -123,6 +126,6 @@ class ShardAllocationDoc(ConfigInjectionMixin, JsonObject):
 
 
 class AllocationSpec(JsonObject):
-    databases = ListProperty(unicode)
-    nodes = ListProperty(unicode)
+    databases = ListProperty(six.text_type)
+    nodes = ListProperty(six.text_type)
     copies = IntegerProperty()

--- a/couchdb_cluster_admin/file_plan.py
+++ b/couchdb_cluster_admin/file_plan.py
@@ -1,11 +1,13 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import argparse
 import itertools
 from collections import defaultdict, namedtuple
 import json
 
-from utils import get_config_from_args, get_shard_allocation, set_up_parser
-from describe import print_shard_table
-from doc_models import ShardAllocationDoc
+from .utils import get_config_from_args, get_shard_allocation, set_up_parser
+from .describe import print_shard_table
+from .doc_models import ShardAllocationDoc
 
 
 Nodefile = namedtuple('Nodefile', 'db_name, node, shard, filename')
@@ -80,7 +82,7 @@ def assemble_shard_allocations_from_plan(config, plan):
 
 
 def show_plan(config, plan):
-    plan_allocation_docs = plan.values()
+    plan_allocation_docs = list(plan.values())
     for doc in plan_allocation_docs:
         doc.set_config(config)
     print_shard_table(plan_allocation_docs)
@@ -111,7 +113,7 @@ def get_missing_files_by_node_and_source(config, plan):
     """
     missing_files = defaultdict(lambda: defaultdict(list))
     important_files_by_node, _ = get_node_files(config, plan)
-    important_files = itertools.chain(*important_files_by_node.values())
+    important_files = itertools.chain(*list(important_files_by_node.values()))
     for db_name, db_files in itertools.groupby(important_files, key=lambda f: f.db_name):
         cluster_allocation_doc = get_shard_allocation(config, db_name)
         for file in db_files:
@@ -125,13 +127,13 @@ def get_missing_files_by_node_and_source(config, plan):
 def run_plan_prune(config, plan, node):
     _, deletable_files_by_node = get_node_files(config, plan)
     for file in sorted(deletable_files_by_node[node], key=lambda f: f.filename):
-        print file.filename
+        print(file.filename)
 
 
 def run_important_plan(config, plan, node):
     important_files_by_node, _ = get_node_files(config, plan)
     for file in sorted(important_files_by_node[node], key=lambda f: f.filename):
-        print file.filename
+        print(file.filename)
 
 
 def get_node_files(config, plan):

--- a/couchdb_cluster_admin/remove_node.py
+++ b/couchdb_cluster_admin/remove_node.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import sys
 
-from utils import (
+from .utils import (
     check_connection,
     confirm,
     do_node_local_request,
@@ -17,7 +19,7 @@ def _remove_shards_from_node(node_details, db_name, node_to_remove):
     db_doc = do_node_local_request(node_details, '_dbs/{}'.format(db_name))
     by_node = db_doc['by_node']
     if node_to_remove not in by_node:
-        print('  Node "{}" has no shards for db "{}"'.format(node_to_remove, db_name))
+        print(('  Node "{}" has no shards for db "{}"'.format(node_to_remove, db_name)))
         return True
 
     if not confirm('Remove shards from db "{}" for "{}"?'.format(db_name, node_to_remove)):
@@ -30,7 +32,7 @@ def _remove_shards_from_node(node_details, db_name, node_to_remove):
         ))
 
     if not shards_to_remove:
-        print('Unable to find shards for db {} belonging to node {}'.format(db_name, node_to_remove))
+        print(('Unable to find shards for db {} belonging to node {}'.format(db_name, node_to_remove)))
         return False
 
     print('  Removing shards from node:\n')
@@ -39,11 +41,11 @@ def _remove_shards_from_node(node_details, db_name, node_to_remove):
         shard_nodes = db_doc['by_range'][shard]
         if node_to_remove in shard_nodes:
             shard_nodes.remove(node_to_remove)
-            print('    {}'.format(shard))
+            print(('    {}'.format(shard)))
         else:
-            print('    Shard {} missing from node: {}'.format(shard, node_to_remove))
+            print(('    Shard {} missing from node: {}'.format(shard, node_to_remove)))
 
-    print('  Updating db config for {}'.format(db_name))
+    print(('  Updating db config for {}'.format(db_name)))
     do_node_local_request(node_details, '_dbs/{}'.format(db_name), method='put', json=db_doc)
     return True
 
@@ -52,7 +54,7 @@ def _remove_node(node_details, new_node):
     if is_node_in_cluster(node_details, new_node):
         remove_node_from_cluster(node_details, new_node)
     else:
-        print('Node not part of the cluster according to {}'.format(node_details.ip))
+        print(('Node not part of the cluster according to {}'.format(node_details.ip)))
 
 
 if __name__ == '__main__':
@@ -74,7 +76,7 @@ if __name__ == '__main__':
     for db_name in get_db_list(node_details):
         if db_name.startswith('_'):
             # TODO: remove this once there's a workaround for https://github.com/apache/couchdb/issues/858
-            print("Skipping db {}".format(db_name))
+            print(("Skipping db {}".format(db_name)))
             continue
         shards_removed = _remove_shards_from_node(node_details, db_name, node_to_remove)
         remove_from_cluster &= shards_removed
@@ -82,6 +84,6 @@ if __name__ == '__main__':
     if remove_from_cluster:
         if confirm("Remove node {} completely from cluster?".format(node_to_remove)):
             _remove_node(node_details, node_to_remove)
-            print('Cluster membership:\n{}'.format(get_membership(node_details).get_printable()))
+            print(('Cluster membership:\n{}'.format(get_membership(node_details).get_printable())))
     else:
         print("Node could not be removed from cluster as it may still have shards")

--- a/couchdb_cluster_admin/remove_node.py
+++ b/couchdb_cluster_admin/remove_node.py
@@ -19,7 +19,7 @@ def _remove_shards_from_node(node_details, db_name, node_to_remove):
     db_doc = do_node_local_request(node_details, '_dbs/{}'.format(db_name))
     by_node = db_doc['by_node']
     if node_to_remove not in by_node:
-        print(('  Node "{}" has no shards for db "{}"'.format(node_to_remove, db_name)))
+        print('  Node "{}" has no shards for db "{}"'.format(node_to_remove, db_name))
         return True
 
     if not confirm('Remove shards from db "{}" for "{}"?'.format(db_name, node_to_remove)):
@@ -32,7 +32,7 @@ def _remove_shards_from_node(node_details, db_name, node_to_remove):
         ))
 
     if not shards_to_remove:
-        print(('Unable to find shards for db {} belonging to node {}'.format(db_name, node_to_remove)))
+        print('Unable to find shards for db {} belonging to node {}'.format(db_name, node_to_remove))
         return False
 
     print('  Removing shards from node:\n')
@@ -41,11 +41,11 @@ def _remove_shards_from_node(node_details, db_name, node_to_remove):
         shard_nodes = db_doc['by_range'][shard]
         if node_to_remove in shard_nodes:
             shard_nodes.remove(node_to_remove)
-            print(('    {}'.format(shard)))
+            print('    {}'.format(shard))
         else:
-            print(('    Shard {} missing from node: {}'.format(shard, node_to_remove)))
+            print('    Shard {} missing from node: {}'.format(shard, node_to_remove))
 
-    print(('  Updating db config for {}'.format(db_name)))
+    print('  Updating db config for {}'.format(db_name))
     do_node_local_request(node_details, '_dbs/{}'.format(db_name), method='put', json=db_doc)
     return True
 
@@ -54,7 +54,7 @@ def _remove_node(node_details, new_node):
     if is_node_in_cluster(node_details, new_node):
         remove_node_from_cluster(node_details, new_node)
     else:
-        print(('Node not part of the cluster according to {}'.format(node_details.ip)))
+        print('Node not part of the cluster according to {}'.format(node_details.ip))
 
 
 if __name__ == '__main__':
@@ -76,7 +76,7 @@ if __name__ == '__main__':
     for db_name in get_db_list(node_details):
         if db_name.startswith('_'):
             # TODO: remove this once there's a workaround for https://github.com/apache/couchdb/issues/858
-            print(("Skipping db {}".format(db_name)))
+            print("Skipping db {}".format(db_name))
             continue
         shards_removed = _remove_shards_from_node(node_details, db_name, node_to_remove)
         remove_from_cluster &= shards_removed
@@ -84,6 +84,6 @@ if __name__ == '__main__':
     if remove_from_cluster:
         if confirm("Remove node {} completely from cluster?".format(node_to_remove)):
             _remove_node(node_details, node_to_remove)
-            print(('Cluster membership:\n{}'.format(get_membership(node_details).get_printable())))
+            print('Cluster membership:\n{}'.format(get_membership(node_details).get_printable()))
     else:
         print("Node could not be removed from cluster as it may still have shards")

--- a/couchdb_cluster_admin/replicate_db_to_new_node.py
+++ b/couchdb_cluster_admin/replicate_db_to_new_node.py
@@ -18,7 +18,7 @@ def _update_db_doc_with_new_node(node_details, db_name, new_node):
     db_doc = do_node_local_request(node_details, '_dbs/{}'.format(db_name))
     by_node = db_doc['by_node']
     if new_node in by_node:
-        print(('  Node "{}" already has shards for db "{}"'.format(new_node, db_name)))
+        print('  Node "{}" already has shards for db "{}"'.format(new_node, db_name))
         return
 
     shards_for_new_node = None
@@ -28,7 +28,7 @@ def _update_db_doc_with_new_node(node_details, db_name, new_node):
             break
 
     if not shards_for_new_node:
-        print(('Unable to find shards for db {}'.format(db_name)))
+        print('Unable to find shards for db {}'.format(db_name))
         return
 
     print('  Adding shards to new node:\n')
@@ -38,12 +38,12 @@ def _update_db_doc_with_new_node(node_details, db_name, new_node):
     for shard in shards_for_new_node:
         current_nodes = db_doc['by_range'][shard]
         if new_node not in current_nodes:
-            print(('    {}'.format(shard)))
+            print('    {}'.format(shard))
             current_nodes.append(new_node)
         else:
-            print(('    Node already had shard: {}'.format(shard)))
+            print('    Node already had shard: {}'.format(shard))
 
-    print(('  Updating db config for {}'.format(db_name)))
+    print('  Updating db config for {}'.format(db_name))
     do_node_local_request(node_details, '_dbs/{}'.format(db_name), method='put', json=db_doc)
 
 

--- a/couchdb_cluster_admin/replicate_db_to_new_node.py
+++ b/couchdb_cluster_admin/replicate_db_to_new_node.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import sys
 
-from utils import (
+from .utils import (
     do_couch_request,
     get_arg_parser,
     node_details_from_args,
@@ -16,7 +18,7 @@ def _update_db_doc_with_new_node(node_details, db_name, new_node):
     db_doc = do_node_local_request(node_details, '_dbs/{}'.format(db_name))
     by_node = db_doc['by_node']
     if new_node in by_node:
-        print('  Node "{}" already has shards for db "{}"'.format(new_node, db_name))
+        print(('  Node "{}" already has shards for db "{}"'.format(new_node, db_name)))
         return
 
     shards_for_new_node = None
@@ -26,7 +28,7 @@ def _update_db_doc_with_new_node(node_details, db_name, new_node):
             break
 
     if not shards_for_new_node:
-        print('Unable to find shards for db {}'.format(db_name))
+        print(('Unable to find shards for db {}'.format(db_name)))
         return
 
     print('  Adding shards to new node:\n')
@@ -36,12 +38,12 @@ def _update_db_doc_with_new_node(node_details, db_name, new_node):
     for shard in shards_for_new_node:
         current_nodes = db_doc['by_range'][shard]
         if new_node not in current_nodes:
-            print('    {}'.format(shard))
+            print(('    {}'.format(shard)))
             current_nodes.append(new_node)
         else:
-            print('    Node already had shard: {}'.format(shard))
+            print(('    Node already had shard: {}'.format(shard)))
 
-    print('  Updating db config for {}'.format(db_name))
+    print(('  Updating db config for {}'.format(db_name)))
     do_node_local_request(node_details, '_dbs/{}'.format(db_name), method='put', json=db_doc)
 
 

--- a/couchdb_cluster_admin/suggest_shard_allocation.py
+++ b/couchdb_cluster_admin/suggest_shard_allocation.py
@@ -386,7 +386,7 @@ def main():
                 print(put_shard_allocation(config, shard_allocation_doc))
             except requests.exceptions.HTTPError as e:
                 if db_name.startswith('_') and e.response.json().get('error') == 'illegal_docid':
-                    print(("Skipping {} (error response was {})".format(db_name, e.response.json())))
+                    print("Skipping {} (error response was {})".format(db_name, e.response.json()))
                 else:
                     raise
 

--- a/couchdb_cluster_admin/suggest_shard_allocation.py
+++ b/couchdb_cluster_admin/suggest_shard_allocation.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import argparse
 from collections import defaultdict
 import json
@@ -5,11 +7,12 @@ import json
 import requests
 from memoized import memoized_property
 
-from utils import humansize, get_arg_parser, get_config_from_args, check_connection, \
+from .utils import humansize, get_arg_parser, get_config_from_args, check_connection, \
     get_db_list, get_db_metadata, get_shard_allocation, do_couch_request, put_shard_allocation
-from describe import print_shard_table
-from file_plan import read_plan_file
-from doc_models import ShardAllocationDoc, AllocationSpec
+from .describe import print_shard_table
+from .file_plan import read_plan_file
+from .doc_models import ShardAllocationDoc, AllocationSpec
+from six.moves import range
 
 
 class _NodeAllocation(object):
@@ -218,19 +221,19 @@ def print_db_info(config):
     """
     info = sorted(get_db_info(config))
     row = u"{: <30}\t{: <20}\t{: <20}\t{: <20}"
-    print row.format(u"Database", u"Data size on Disk", u"View size on Disk", u"Number of shards")
+    print(row.format(u"Database", u"Data size on Disk", u"View size on Disk", u"Number of shards"))
     for db_name, size, view_sizes, shards, _ in info:
-        print row.format(
+        print(row.format(
             db_name,
             humansize(size),
             humansize(sum([view_size for view_name, view_size in view_sizes.items()])),
             len(shards)
-        )
+        ))
 
 
 def get_shard_sizes(db_info, databases):
     return [
-        (1.0 * sum([size] + views_size.values()) / len(shards), (shard_name, db_name))
+        (1.0 * sum([size] + list(views_size.values())) / len(shards), (shard_name, db_name))
         for db_name, size, views_size, shards, _ in db_info
         for shard_name in shards if db_name in databases
     ]
@@ -275,7 +278,7 @@ def make_suggested_allocation_by_db(config, db_info, allocation_specs):
             existing_allocation=existing_allocation
         )
         for node_allocation in suggested_shard_allocation:
-            print "{}\t{}".format(config.format_node_name(allocation.nodes[node_allocation.i]), humansize(node_allocation.size))
+            print("{}\t{}".format(config.format_node_name(allocation.nodes[node_allocation.i]), humansize(node_allocation.size)))
             for shard_name, db_name in node_allocation.shards:
                 suggested_allocation_by_db[db_name].append((allocation.nodes[node_allocation.i], shard_name))
 
@@ -380,10 +383,10 @@ def main():
         for shard_allocation_doc in shard_allocations:
             db_name = shard_allocation_doc.db_name
             try:
-                print put_shard_allocation(config, shard_allocation_doc)
+                print(put_shard_allocation(config, shard_allocation_doc))
             except requests.exceptions.HTTPError as e:
                 if db_name.startswith('_') and e.response.json().get('error') == 'illegal_docid':
-                    print("Skipping {} (error response was {})".format(db_name, e.response.json()))
+                    print(("Skipping {} (error response was {})".format(db_name, e.response.json())))
                 else:
                     raise
 

--- a/couchdb_cluster_admin/utils.py
+++ b/couchdb_cluster_admin/utils.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import argparse
 import getpass
 from collections import namedtuple
@@ -9,7 +10,10 @@ import time
 import yaml
 from requests import HTTPError
 
-from doc_models import MembershipDoc, ShardAllocationDoc
+from .doc_models import MembershipDoc, ShardAllocationDoc
+import six
+from six.moves import range
+from six.moves import input
 
 NodeDetails = namedtuple('NodeDetails', 'ip port node_local_port username password socks_port')
 
@@ -94,7 +98,7 @@ def put_shard_allocation(config, shard_allocation_doc):
 
 
 def confirm(msg):
-    return raw_input(msg + "\n(y/n)") == 'y'
+    return input(msg + "\n(y/n)") == 'y'
 
 
 def get_arg_parser(command_description):
@@ -120,7 +124,7 @@ class Config(JsonObject):
     control_node_port = IntegerProperty()
     control_node_local_port = IntegerProperty()
     username = StringProperty()
-    aliases = DictProperty(unicode)
+    aliases = DictProperty(six.text_type)
 
     def set_password(self, password):
         self._password = password

--- a/couchdb_cluster_admin/utils.py
+++ b/couchdb_cluster_admin/utils.py
@@ -156,7 +156,7 @@ def get_config_from_args(args):
     if args.conf:
         with open(args.conf) as f:
             # https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
-            config = Config.wrap(yaml.safe_load(f))
+            config = Config.wrap(yaml.load(f))
     else:
         config = Config(
             control_node_ip=args.control_node_ip,

--- a/couchdb_cluster_admin/utils.py
+++ b/couchdb_cluster_admin/utils.py
@@ -155,7 +155,8 @@ class Config(JsonObject):
 def get_config_from_args(args):
     if args.conf:
         with open(args.conf) as f:
-            config = Config.wrap(yaml.load(f))
+            # https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
+            config = Config.wrap(yaml.safe_load(f))
     else:
         config = Config(
             control_node_ip=args.control_node_ip,

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from __future__ import print_function
 from setuptools import find_packages, setup
 
 # For compatibility with pip-compile,

--- a/test/test.bats
+++ b/test/test.bats
@@ -82,15 +82,15 @@ function wait_for_couch_ping {
     python -m couchdb_cluster_admin.suggest_shard_allocation --conf=test/local.yml --from-plan=test/local.plan.json --commit-to-couchdb
 
     echo $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount)
-    sleep 5
+    sleep 10
     echo $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount)
-    sleep 5
+    sleep 10
     echo $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount)
-    sleep 5
+    sleep 10
     echo $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount)
-    sleep 5
+    sleep 10
     echo $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount)
-    sleep 5
+    sleep 10
     echo $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount)
     [ "$(doccount)" = '10' ]
     echo $(longform_doccount) $(longform_doccount) $(longform_doccount)

--- a/test/test.bats
+++ b/test/test.bats
@@ -13,7 +13,7 @@ function generate_db_name {
 function setup {
     db_name="$(generate_db_name)"
     echo "PUT" $db_name
-    curl -sX PUT http://localhost:15984/${db_name}
+    curl -sX PUT "http://localhost:15984/${db_name}?q=1&n=1"
     curl -sX PUT http://localhost:15984/_users
     curl -sX PUT http://localhost:15984/_users/org.couchdb.user:jan \
      -H "Accept: application/json" \

--- a/test/test.bats
+++ b/test/test.bats
@@ -23,7 +23,7 @@ function longform_doccount {
 function make_rsync_files {
     FROM_NODE=$1
     TO_NODE=$2
-    python couchdb_cluster_admin/file_plan.py important --conf test/local.yml --from-plan=test/local.plan.json --node $TO_NODE > test/$TO_NODE.files.txt
+    python -m couchdb_cluster_admin.file_plan important --conf test/local.yml --from-plan=test/local.plan.json --node $TO_NODE > test/$TO_NODE.files.txt
 }
 
 function rsync_files {
@@ -41,9 +41,9 @@ function wait_for_couch_ping {
 }
 
 @test "add shards from one node to a cluster" {
-    python couchdb_cluster_admin/suggest_shard_allocation.py --conf=test/local.yml --allocate node1:1 --commit-to-couchdb
+    python -m couchdb_cluster_admin.suggest_shard_allocation --conf=test/local.yml --allocate node1:1 --commit-to-couchdb
 
-    python couchdb_cluster_admin/suggest_shard_allocation.py --conf=test/local.yml --allocate node1:1 node2,node3,node4:2 --save-plan=test/local.plan.json
+    python -m couchdb_cluster_admin.suggest_shard_allocation --conf=test/local.yml --allocate node1:1 node2,node3,node4:2 --save-plan=test/local.plan.json
 
     for i in {1..10}
     do
@@ -69,7 +69,7 @@ function wait_for_couch_ping {
     run rsync_files node1 node3 && [ "$status" = '23' ]
     run rsync_files node1 node4 && [ "$status" = '23' ]
 
-    python couchdb_cluster_admin/suggest_shard_allocation.py --conf=test/local.yml --from-plan=test/local.plan.json --commit-to-couchdb
+    python -m couchdb_cluster_admin.suggest_shard_allocation --conf=test/local.yml --from-plan=test/local.plan.json --commit-to-couchdb
 
     echo $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount) $(doccount)
     sleep 5

--- a/test/test.bats
+++ b/test/test.bats
@@ -1,7 +1,17 @@
 #!/usr/bin/env bats
 
+function generate_db_name {
+    PYTHON_VERSION=$(python -c 'import sys; print(sys.version_info[0])')
+    if [ $PYTHON_VERSION == "3" ]
+    then
+        echo "test$(head -n20 /dev/random | python -c 'import hashlib, sys; print(hashlib.md5(sys.stdin.buffer.read()).hexdigest())')"
+    else
+        echo "test$(head -n20 /dev/random | python -c 'import hashlib, sys; print(hashlib.md5(sys.stdin.read()).hexdigest())')"
+    fi
+}
+
 function setup {
-    db_name=test$(head -n20 /dev/random | python -c 'import hashlib, sys; print(hashlib.md5(sys.stdin.read()).hexdigest())')
+    db_name="$(generate_db_name)"
     echo "PUT" $db_name
     curl -sX PUT http://localhost:15984/${db_name}
     curl -sX PUT http://localhost:15984/_users

--- a/test/test.bats
+++ b/test/test.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 function setup {
-    db_name=test$(head -n20 /dev/random | python -c 'import hashlib, sys; print hashlib.md5(sys.stdin.read()).hexdigest()')
+    db_name=test$(head -n20 /dev/random | python -c 'import hashlib, sys; print(hashlib.md5(sys.stdin.read()).hexdigest())')
     echo "PUT" $db_name
     curl -sX PUT http://localhost:15984/${db_name}
     curl -sX PUT http://localhost:15984/_users

--- a/test/test.bats
+++ b/test/test.bats
@@ -13,7 +13,7 @@ function generate_db_name {
 function setup {
     db_name="$(generate_db_name)"
     echo "PUT" $db_name
-    curl -sX PUT "http://localhost:15984/${db_name}?q=1&n=1"
+    curl -sX PUT "http://localhost:15984/${db_name}?q=2&n=2"
     curl -sX PUT http://localhost:15984/_users
     curl -sX PUT http://localhost:15984/_users/org.couchdb.user:jan \
      -H "Accept: application/json" \

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from mock.mock import patch
 
 from couchdb_cluster_admin.suggest_shard_allocation import suggest_shard_allocation, _NodeAllocation


### PR DESCRIPTION
- To upgrade [commcare-cloud](https://github.com/dimagi/commcare-cloud/pull/3751) to support python 3, `couchdb-cluster-admin` should also be upgraded to support python3.
- This PR is output of using [modernize ](https://python-modernize.readthedocs.io/en/latest/) tool and running the command `python-modernize -w -n .` in the repository.
- Added support of build for python 3 in `.travis.yml`