### PR TITLE
Upgrade jsonobject to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ greenlet==0.4.15
     # via gevent
 idna==2.8
     # via requests
-jsonobject==0.9.8
+jsonobject==2.0.0
     # via couchdb-cluster-admin (setup.py)
 pyyaml==5.4.1
     # via couchdb-cluster-admin (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     install_requires=(
         'argparse>=1.4',
         'gevent',
-        'jsonobject>=0.8.0',
+        'jsonobject',
         'PyYAML',
         'requests',
         'dimagi-memoized'


### PR DESCRIPTION
In preparation for supporting python 3.10, jsonobject needs to be upgraded to 2.0.0. ~I noticed running `pip-compile --output-file=requirements.txt setup.py` made unrelated formatting changes to requirements.txt, so I did that on a separate commit.~

Tests cover shard allocation, which includes all fields imported from jsonobject.