### PR TITLE
Add license file to metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,8 @@
 [bdist_wheel]
 universal=1
 
+[metadata]
+license_file = LICENSE
+
 [flake8]
 exclude = ./build


### PR DESCRIPTION
Our docs say to reference the license file in metadata when setting up a new python package, so I figured it should be the same here. I also don't remember seeing this file referenced anywhere else.