### PR TITLE
add props in ShardAllocationDoc

### DIFF
--- a/couchdb_cluster_admin/doc_models.py
+++ b/couchdb_cluster_admin/doc_models.py
@@ -43,6 +43,7 @@ class ShardAllocationDoc(ConfigInjectionMixin, JsonObject):
     changelog = ListProperty(ListProperty(str))
     shard_suffix = ListProperty(int)
     by_range = DictProperty(ListProperty(str))
+    props = DictProperty(dict)
 
     @property
     def usable_shard_suffix(self):


### PR DESCRIPTION
I got the following error while trying to replicate data to new nodes in backup production env while ran plan for the migration.

```
Traceback (most recent call last):
  File "jsonobject/base.pyx", line 202, in jsonobject.base.JsonObjectBase.__init__
  File "jsonobject/base.pyx", line 239, in jsonobject.base.JsonObjectBase.set_raw_value
  File "jsonobject/base.pyx", line 322, in jsonobject.base.JsonObjectBase.__setattr__
AttributeError: 'props' is not defined in schema (not a valid property)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/aphulera/.virtualenvs/cchq/bin/cchq", line 33, in <module>
    sys.exit(load_entry_point('commcare-cloud', 'console_scripts', 'cchq')())
  File "/home/aphulera/commcare-cloud/src/commcare_cloud/commcare_cloud.py", line 268, in main
    exit_code = call_commcare_cloud()
  File "/home/aphulera/commcare-cloud/src/commcare_cloud/commcare_cloud.py", line 237, in call_commcare_cloud
    exit_code = command.run(args, unknown_args)
  File "/home/aphulera/commcare-cloud/src/commcare_cloud/commands/migrations/couchdb.py", line 118, in run
    return plan(migration)
  File "/home/aphulera/commcare-cloud/src/commcare_cloud/commands/migrations/couchdb.py", line 311, in plan
    shard_allocations = generate_shard_plan(migration)
  File "/home/aphulera/commcare-cloud/src/commcare_cloud/commands/migrations/couchdb.py", line 319, in generate_shard_plan
    shard_allocations = generate_shard_allocation(
  File "/home/aphulera/.virtualenvs/cchq/lib/python3.10/site-packages/couchdb_cluster_admin/suggest_shard_allocation.py", line 424, in generate_shard_allocation
    db_info = get_db_info(config)
  File "/home/aphulera/.virtualenvs/cchq/lib/python3.10/site-packages/couchdb_cluster_admin/suggest_shard_allocation.py", line 209, in get_db_info
    gevent.joinall(processes, raise_error=True)
  File "src/gevent/greenlet.py", line 1065, in gevent._gevent_cgreenlet.joinall
  File "src/gevent/greenlet.py", line 1081, in gevent._gevent_cgreenlet.joinall
  File "src/gevent/greenlet.py", line 373, in gevent._gevent_cgreenlet.Greenlet._raise_exception
  File "/home/aphulera/.virtualenvs/cchq/lib/python3.10/site-packages/gevent/_compat.py", line 49, in reraise
    raise value.with_traceback(tb)
  File "src/gevent/greenlet.py", line 908, in gevent._gevent_cgreenlet.Greenlet.run
  File "/home/aphulera/.virtualenvs/cchq/lib/python3.10/site-packages/couchdb_cluster_admin/suggest_shard_allocation.py", line 190, in _gather_db_shard_names
    doc = get_shard_allocation(config, db_name)
  File "/home/aphulera/.virtualenvs/cchq/lib/python3.10/site-packages/couchdb_cluster_admin/utils.py", line 81, in get_shard_allocation
    shard_allocation_doc = ShardAllocationDoc.wrap(do_node_local_request(node_details, '_dbs/{}'.format(db_name)))
  File "jsonobject/base.pyx", line 251, in jsonobject.base.JsonObjectBase.wrap
  File "jsonobject/base.pyx", line 204, in jsonobject.base.JsonObjectBase.__init__
jsonobject.exceptions.WrappingAttributeError: can't set attribute corresponding to 'props' on a <class 'couchdb_cluster_admin.doc_models.ShardAllocationDoc'> while wrapping {'_id': 'commcarehq__users-tmp', '_rev': '2-28b005e091d7fdc0d0933658d318211c', 'shard_suffix': [46, 49, 54, 57, 56, 49, 55, 57, 56, 48, 50], 'changelog': [], 'by_node': {'couchdb@10.212.41.153': ['00000000-1fffffff', '20000000-3fffffff', '40000000-5fffffff', '60000000-7fffffff', '80000000-9fffffff', 'a0000000-bfffffff', 'c0000000-dfffffff', 'e0000000-ffffffff'], 'couchdb@10.212.41.29': ['00000000-1fffffff', '20000000-3fffffff', '40000000-5fffffff', '60000000-7fffffff', '80000000-9fffffff', 'a0000000-bfffffff', 'c0000000-dfffffff', 'e0000000-ffffffff'], 'couchdb@10.212.41.62': ['00000000-1fffffff', '20000000-3fffffff', '40000000-5fffffff', '60000000-7fffffff', '80000000-9fffffff', 'a0000000-bfffffff', 'c0000000-dfffffff', 'e0000000-ffffffff']}, 'by_range': {'00000000-1fffffff': ['couchdb@10.212.41.29', 'couchdb@10.212.41.62', 'couchdb@10.212.41.153'], '20000000-3fffffff': ['couchdb@10.212.41.29', 'couchdb@10.212.41.62', 'couchdb@10.212.41.153'], '40000000-5fffffff': ['couchdb@10.212.41.29', 'couchdb@10.212.41.62', 'couchdb@10.212.41.153'], '60000000-7fffffff': ['couchdb@10.212.41.29', 'couchdb@10.212.41.62', 'couchdb@10.212.41.153'], '80000000-9fffffff': ['couchdb@10.212.41.29', 'couchdb@10.212.41.62', 'couchdb@10.212.41.153'], 'a0000000-bfffffff': ['couchdb@10.212.41.29', 'couchdb@10.212.41.62', 'couchdb@10.212.41.153'], 'c0000000-dfffffff': ['couchdb@10.212.41.29', 'couchdb@10.212.41.62', 'couchdb@10.212.41.153'], 'e0000000-ffffffff': ['couchdb@10.212.41.29', 'couchdb@10.212.41.62', 'couchdb@10.212.41.153']}, 'props': {}}
```

This is a new property that is available in all the new dbs that are created, the usage is not documented but found a reference in https://docs.couchdb.org/en/stable/partitioned-dbs/index.html\#partitions-by-example.

The issue in coming in `commcarehq__users-tmp` db that was newly created in couchdb 3.x. 
