### PR TITLE
Bump to 0.7.4

### DIFF
--- a/couchdb_cluster_admin/__init__.py
+++ b/couchdb_cluster_admin/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"


### PR DESCRIPTION
Followup to https://github.com/dimagi/couchdb-cluster-admin/pull/58. Probably should have done as part of that so that any new dev releases are marked as 0.7.4, not 0.7.3 which has already been released.